### PR TITLE
Session and Checkout fixtures, Checkout tests

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -1,1 +1,2 @@
 BASE_URL = "https://automation-portal-bootcamp.vercel.app"
+TEST_USER = {"email": "team2@taqc.com", "password": "team2"}

--- a/pages/checkout_page.py
+++ b/pages/checkout_page.py
@@ -1,4 +1,5 @@
 from playwright.async_api import Page
+from config.config import BASE_URL
 
 class CheckoutPage:
     def __init__(self, page: Page):
@@ -23,7 +24,9 @@ class CheckoutPage:
         await self.page.locator(selector).scroll_into_view_if_needed()
         await self.page.fill(selector, value)
 
-    # change this so it receives a list/dictionary maybe?
+    async def navigate(self):
+        await self.page.goto(f"{BASE_URL}/checkout")
+
     async def fill_billing_details(
             self,
             first_name=None,

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_default_fixture_loop_scope = function

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,24 @@
 import pytest_asyncio
+from config.config import TEST_USER
 from playwright.async_api import async_playwright
+
+@pytest_asyncio.fixture(loop_scope="module")
+async def checkout_valid_data():
+    yield {
+        "first_name": "first",
+        "last_name": "last",
+        "country": "Spain",
+        "city": "city",
+        "address": "address",
+        "phone": "987654321",
+        "email": TEST_USER["email"] or "email@example.com",
+        "notes": "notes",
+        "discount_code": "discount",
+        "card_number": "4242424242424242",
+        "card_date": "12/12",
+        "card_cvc": "123",
+        "tos_checkbox": True
+    }
 
 @pytest_asyncio.fixture(loop_scope="module")
 async def browser():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import pytest_asyncio
+from playwright.async_api import async_playwright
+
+@pytest_asyncio.fixture(loop_scope="module")
+async def browser():
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(headless=False)
+        yield browser
+        await browser.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,12 @@
 import pytest_asyncio
+from typing import Dict, List, Any, AsyncGenerator
+from playwright.async_api import async_playwright, Browser, Cookie
 from config.config import TEST_USER
-from playwright.async_api import async_playwright
+from pages import AutomationPortal, Navbar, LoginPopup
 
-@pytest_asyncio.fixture(loop_scope="module")
-async def checkout_valid_data():
-    yield {
+@pytest_asyncio.fixture(loop_scope="module", scope="module")
+async def checkout_valid_data() -> Dict[str, Any]:
+    return {
         "first_name": "first",
         "last_name": "last",
         "country": "Spain",
@@ -21,8 +23,29 @@ async def checkout_valid_data():
     }
 
 @pytest_asyncio.fixture(loop_scope="module")
-async def browser():
+async def browser() -> AsyncGenerator[Browser, None]:
     async with async_playwright() as p:
         browser = await p.chromium.launch(headless=False)
         yield browser
         await browser.close()
+
+@pytest_asyncio.fixture(loop_scope="module", scope="module")
+async def session() -> List[Cookie]:
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(headless=False)
+        page = await browser.new_page()
+        test_email = TEST_USER["email"] or "email@example.com"
+        test_password = TEST_USER["password"] or "password"
+
+        portal = AutomationPortal(page)
+        navbar = Navbar(page)
+        login_popup = LoginPopup(page)
+
+        await portal.navigate()
+        await portal.close_newsletter_popup()
+        await navbar.navigate_to_account()
+        await login_popup.fill_login_popup(test_email, test_password)
+        await login_popup.submit_login_popup()
+        session =  await page.context.cookies()
+        await browser.close()
+        return session

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,8 @@
 import pytest_asyncio
+import requests
 from typing import Dict, List, Any, AsyncGenerator
 from playwright.async_api import async_playwright, Browser, Cookie
-from config.config import TEST_USER
+from config.config import BASE_URL, TEST_USER
 from pages import AutomationPortal, Navbar, LoginPopup
 
 @pytest_asyncio.fixture(loop_scope="module", scope="module")
@@ -30,7 +31,7 @@ async def browser() -> AsyncGenerator[Browser, None]:
         await browser.close()
 
 @pytest_asyncio.fixture(loop_scope="module", scope="module")
-async def session() -> List[Cookie]:
+async def session_ui() -> List[Cookie]:
     async with async_playwright() as p:
         browser = await p.chromium.launch(headless=False)
         page = await browser.new_page()
@@ -49,3 +50,47 @@ async def session() -> List[Cookie]:
         session =  await page.context.cookies()
         await browser.close()
         return session
+
+@pytest_asyncio.fixture(loop_scope="module", scope="module")
+async def session() -> List[Cookie]:
+    session = requests.Session()
+
+    # GET CSRF Token
+    response_csrf = session.get(f"{BASE_URL}/api/auth/csrf")
+    if response_csrf.status_code == 200:
+        csrf_token = response_csrf.json().get('csrfToken')
+    else:
+        raise requests.exceptions.HTTPError(f"Failed to retrieve CSRF token: {response_csrf.status_code}")
+
+    # POST Login
+    data = {
+        "email": TEST_USER["email"],
+        "password": TEST_USER["password"],
+        "redirect": "false",
+        "csrfToken": csrf_token,
+        "callbackUrl": f"{BASE_URL}/login",
+        "json": "true"
+    }
+    response_login = session.post(f"{BASE_URL}/api/auth/callback/credentials", data=data)
+    if response_login.status_code != 200:
+        raise requests.exceptions.HTTPError(f"Login failed: {response_login.status_code}")
+
+    # GET Session
+    response_session = session.get(f"{BASE_URL}/api/auth/session")
+    if response_session.status_code != 200:
+        raise requests.exceptions.HTTPError(f"Failed to retrieve session cookie: {response_session.status_code}")
+
+    context_cookies = []
+    for cookie in session.cookies:
+        context_cookies.append(Cookie(
+            name=cookie.name,
+            value=cookie.value,
+            domain=cookie.domain,
+            path=cookie.path,
+            expires=cookie.expires or -1,
+            httpOnly=cookie.has_nonstandard_attr('HttpOnly'),
+            secure=cookie.secure,
+            sameSite=cookie._rest.get('SameSite', None)
+        ))
+
+    return context_cookies

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -1,11 +1,13 @@
 import pytest
 from config.config import TEST_USER
 from pages import AutomationPortal, CheckoutPage, Navbar, LoginPopup, CartSidebar
+from playwright.async_api import TimeoutError
 
 @pytest.mark.asyncio(loop_scope = "module")
-async def test_checkout(browser):
+async def test_checkout_valid_data(browser, checkout_valid_data):
     page = await browser.new_page()
-    order_saved_message = page.locator("p:has-text('Order saved successfully!')")
+    test_email = TEST_USER["email"] or "email@example.com"
+    test_password = TEST_USER["password"] or "password"
 
     portal = AutomationPortal(page)
     checkout = CheckoutPage(page)
@@ -16,18 +18,100 @@ async def test_checkout(browser):
     await portal.navigate()
     await portal.close_newsletter_popup()
     await navbar.navigate_to_account()
-    await login_popup.fill_login_popup(TEST_USER["email"], TEST_USER["password"])
+    await login_popup.fill_login_popup(test_email, test_password)
     await login_popup.submit_login_popup()
     await page.keyboard.press("Escape") # To remove bugged overlay in "My Account" page
     await navbar.open_cart_sidebar()
     await cart_sidebar.click_tos_checkbox()
     await cart_sidebar.go_to_checkout()
-    await checkout.fill_billing_details("first", "last", "Spain", "city", "address", "phone", "email", "notes")
-    await checkout.apply_discount_code("discount")
-    await checkout.fill_credit_card_details("4242424242424242", "12/12", "123")
-    await checkout.click_tos_checkbox()
+    await checkout.fill_billing_details(
+        checkout_valid_data["first_name"],
+        checkout_valid_data["last_name"],
+        checkout_valid_data["country"],
+        checkout_valid_data["city"],
+        checkout_valid_data["address"],
+        checkout_valid_data["phone"],
+        checkout_valid_data["email"],
+        checkout_valid_data["notes"]
+    )
+    await checkout.apply_discount_code(checkout_valid_data["discount_code"])
+    await checkout.fill_credit_card_details(
+        checkout_valid_data["card_number"],
+        checkout_valid_data["card_date"],
+        checkout_valid_data["card_cvc"]
+    )
+    if checkout_valid_data["tos_checkbox"]: await checkout.click_tos_checkbox()
     await checkout.place_order()
 
-    await order_saved_message.scroll_into_view_if_needed(timeout=5000)
-    order_placed = await order_saved_message.is_visible()
-    assert order_placed, "F: Order with correct details wasn't placed (5s timeout)"
+    order_saved_message = "p:has-text('Order saved successfully!')"
+    try:
+        await page.wait_for_selector(order_saved_message, timeout=2000)
+        order_placed = await page.locator(order_saved_message).is_visible()
+    except TimeoutError:
+        order_placed = False
+    assert order_placed, "F: Order with correct details wasn't placed after 2s"
+
+
+required_fields = [ "first_name",
+                   "last_name",
+                   "country",
+                   "city",
+                   "address",
+                   "phone",
+                   "email",
+                   "card_number",
+                   "card_date",
+                   "card_cvc",
+                   "tos_checkbox"
+                   ]
+@pytest.mark.parametrize("field_to_empty", required_fields)
+@pytest.mark.asyncio(loop_scope = "module")
+async def test_checkout_empty_required_fields(browser, checkout_valid_data, field_to_empty):
+    page = await browser.new_page()
+    test_email = TEST_USER["email"] or "email@example.com"
+    test_password = TEST_USER["password"] or "password"
+
+    portal = AutomationPortal(page)
+    checkout = CheckoutPage(page)
+    navbar = Navbar(page)
+    login_popup = LoginPopup(page)
+    cart_sidebar = CartSidebar(page)
+
+    checkout_data = checkout_valid_data.copy()
+    checkout_data[field_to_empty] = ""
+
+    await portal.navigate()
+    await portal.close_newsletter_popup()
+    await navbar.navigate_to_account()
+    await login_popup.fill_login_popup(test_email, test_password)
+    await login_popup.submit_login_popup()
+    await page.keyboard.press("Escape") # To remove bugged overlay in "My Account" page
+    await navbar.open_cart_sidebar()
+    await cart_sidebar.click_tos_checkbox()
+    await cart_sidebar.go_to_checkout()
+    await checkout.fill_billing_details(
+        checkout_data["first_name"],
+        checkout_data["last_name"],
+        checkout_data["country"],
+        checkout_data["city"],
+        checkout_data["address"],
+        checkout_data["phone"],
+        checkout_data["email"],
+        checkout_data["notes"]
+    )
+    await checkout.apply_discount_code(checkout_data["discount_code"])
+    await checkout.fill_credit_card_details(
+        checkout_data["card_number"],
+        checkout_data["card_date"],
+        checkout_data["card_cvc"]
+    )
+    if checkout_data["tos_checkbox"]: await checkout.click_tos_checkbox()
+    await checkout.place_order()
+
+    order_saved_message = "p:has-text('Order saved successfully!')"
+    try:
+        await page.wait_for_selector(order_saved_message, timeout=2000)
+        order_placed = await page.locator(order_saved_message).is_visible()
+    except TimeoutError:
+        order_placed = False
+    assert not order_placed, f"F: Order was placed with required field {field_to_empty} empty"

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -2,42 +2,8 @@ import pytest
 from pages import CheckoutPage
 from playwright.async_api import TimeoutError
 
-@pytest.mark.asyncio(loop_scope = "module")
-async def test_checkout_valid_data(browser, session, checkout_valid_data):
-    context = await browser.new_context()
-    await context.add_cookies(session)
-    page = await context.new_page()
-
-    checkout = CheckoutPage(page)
-    await checkout.navigate()
-    await checkout.fill_billing_details(
-        checkout_valid_data["first_name"],
-        checkout_valid_data["last_name"],
-        checkout_valid_data["country"],
-        checkout_valid_data["city"],
-        checkout_valid_data["address"],
-        checkout_valid_data["phone"],
-        checkout_valid_data["email"],
-        checkout_valid_data["notes"]
-    )
-    await checkout.apply_discount_code(checkout_valid_data["discount_code"])
-    await checkout.fill_credit_card_details(
-        checkout_valid_data["card_number"],
-        checkout_valid_data["card_date"],
-        checkout_valid_data["card_cvc"]
-    )
-    if checkout_valid_data["tos_checkbox"]: await checkout.click_tos_checkbox()
-    await checkout.place_order()
-
-    order_saved_message = "p:has-text('Order saved successfully!')"
-    try:
-        await page.wait_for_selector(order_saved_message, timeout=2000)
-        order_placed = await page.locator(order_saved_message).is_visible()
-    except TimeoutError:
-        order_placed = False
-    assert order_placed, "Order with correct details wasn't placed after 2s"
-
-required_fields = [ "first_name",
+required_fields_to_empty = [ None,
+                   "first_name",
                    "last_name",
                    "country",
                    "city",
@@ -49,7 +15,7 @@ required_fields = [ "first_name",
                    "card_cvc",
                    "tos_checkbox"
                    ]
-@pytest.mark.parametrize("field_to_empty", required_fields)
+@pytest.mark.parametrize("field_to_empty", required_fields_to_empty)
 @pytest.mark.asyncio(loop_scope = "module")
 async def test_checkout_required_fields(browser, session, checkout_valid_data, field_to_empty):
     context = await browser.new_context()
@@ -59,7 +25,7 @@ async def test_checkout_required_fields(browser, session, checkout_valid_data, f
     checkout = CheckoutPage(page)
     await checkout.navigate()
     checkout_data = checkout_valid_data.copy()
-    checkout_data[field_to_empty] = ""
+    if field_to_empty: checkout_data[field_to_empty] = ""
     await checkout.fill_billing_details(
         checkout_data["first_name"],
         checkout_data["last_name"],
@@ -85,4 +51,8 @@ async def test_checkout_required_fields(browser, session, checkout_valid_data, f
         order_placed = await page.locator(order_saved_message).is_visible()
     except TimeoutError:
         order_placed = False
-    assert not order_placed, f"Order was placed with required field {field_to_empty} empty"
+
+    if field_to_empty:
+        assert not order_placed, f"Order was placed with required field {field_to_empty} empty"
+    else:
+        assert order_placed, "Order with valid data wasn't placed after 2s"

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -1,0 +1,33 @@
+import pytest
+from config.config import TEST_USER
+from pages import AutomationPortal, CheckoutPage, Navbar, LoginPopup, CartSidebar
+
+@pytest.mark.asyncio(loop_scope = "module")
+async def test_checkout(browser):
+    page = await browser.new_page()
+    order_saved_message = page.locator("p:has-text('Order saved successfully!')")
+
+    portal = AutomationPortal(page)
+    checkout = CheckoutPage(page)
+    navbar = Navbar(page)
+    login_popup = LoginPopup(page)
+    cart_sidebar = CartSidebar(page)
+
+    await portal.navigate()
+    await portal.close_newsletter_popup()
+    await navbar.navigate_to_account()
+    await login_popup.fill_login_popup(TEST_USER["email"], TEST_USER["password"])
+    await login_popup.submit_login_popup()
+    await page.keyboard.press("Escape") # To remove bugged overlay in "My Account" page
+    await navbar.open_cart_sidebar()
+    await cart_sidebar.click_tos_checkbox()
+    await cart_sidebar.go_to_checkout()
+    await checkout.fill_billing_details("first", "last", "Spain", "city", "address", "phone", "email", "notes")
+    await checkout.apply_discount_code("discount")
+    await checkout.fill_credit_card_details("4242424242424242", "12/12", "123")
+    await checkout.click_tos_checkbox()
+    await checkout.place_order()
+
+    await order_saved_message.scroll_into_view_if_needed(timeout=5000)
+    order_placed = await order_saved_message.is_visible()
+    assert order_placed, "F: Order with correct details wasn't placed (5s timeout)"


### PR DESCRIPTION
Adds `conftest.py`, `test_checkout.py` and `pytest.ini` files:
### `conftest.py`
- Includes browser, session (both using API requests and UI) and valid checkout data fixtures
### `test_checkout.py`
- Includes a test for empty required fields at checkout
### `pytest.ini`
- Sets the default fixture loop scope to `function`
